### PR TITLE
Implement Feature extract and allow asymetric mapping (Mapping feature)

### DIFF
--- a/lantz_core/features/mappings.py
+++ b/lantz_core/features/mappings.py
@@ -26,8 +26,8 @@ class Mapping(Feature):
     """
     def __init__(self, getter=None, setter=None, mapping=None, get_format='',
                  retries=0, checks=None, discard=None):
-        super(Mapping, self).__init__(getter, setter, get_format, retries,
-                                      checks, discard)
+        Feature.__init__(self, getter, setter, get_format, retries,
+                         checks, discard)
 
         mapping = mapping if mapping else {}
         self._map = mapping
@@ -61,8 +61,8 @@ class Bool(Mapping):
     """
     def __init__(self, getter=None, setter=None, mapping=None, aliases=None,
                  get_format='', retries=0, checks=None, discard=None, ):
-        super(Bool, self).__init__(getter, setter, mapping, get_format,
-                                   retries, checks, discard)
+        Mapping.__init__(self, getter, setter, mapping, get_format,
+                         retries, checks, discard)
 
         self._aliases = {True: True, False: False}
         if aliases:

--- a/lantz_core/features/mappings.py
+++ b/lantz_core/features/mappings.py
@@ -20,8 +20,12 @@ class Mapping(Feature):
 
     Parameters
     ----------
-    mapping : dict
-        Mapping between the user values and instrument values.
+    mapping : dict or tuple
+        Mapping between the user values and instrument values. If a tuple is
+        provided the first element should be the mapping between user values
+        and instrument input, the second between instrument output and user
+        values. This allows to handle asymetric case in which the instrument
+        expect a command (ex: CMD ON) but when queried return 1.
 
     """
     def __init__(self, getter=None, setter=None, mapping=None, get_format='',
@@ -30,8 +34,12 @@ class Mapping(Feature):
                          checks, discard)
 
         mapping = mapping if mapping else {}
-        self._map = mapping
-        self._imap = {v: k for k, v in mapping.items()}
+        if isinstance(mapping, (tuple, list)):
+            self._map = mapping[0]
+            self._imap = mapping[1]
+        else:
+            self._map = mapping
+            self._imap = {v: k for k, v in mapping.items()}
         self.creation_kwargs['mapping'] = mapping
 
         self.modify_behavior('post_get', self.reverse_map_value,

--- a/lantz_core/features/register.py
+++ b/lantz_core/features/register.py
@@ -27,10 +27,10 @@ class Register(Feature):
         the values are used to specify the bits to consider.
 
     """
-    def __init__(self, getter=None, setter=None, names=(), get_format='',
+    def __init__(self, getter=None, setter=None, names=(), extract='',
                  retries=0, checks=None, discard=None):
-        super(Register, self).__init__(getter, setter, get_format, retries,
-                                       checks, discard)
+        Feature.__init__(self, getter, setter, extract, retries,
+                         checks, discard)
 
         if isinstance(names, dict):
             aux = list(range(8))
@@ -63,7 +63,10 @@ class Register(Feature):
 
         """
         val = int(value)
-        bit_conversion = lambda x, i: bool(x & (1 << i))
+
+        def bit_conversion(x, i):
+            return bool(x & (1 << i))
+
         return OrderedDict((n, bit_conversion(val, i))
                            for i, n in enumerate(self.names)
                            if n is not None)

--- a/lantz_core/features/scalars.py
+++ b/lantz_core/features/scalars.py
@@ -33,10 +33,10 @@ class Enumerable(Feature):
         Permitted values for the property.
 
     """
-    def __init__(self, getter=None, setter=None, values=(), get_format='',
+    def __init__(self, getter=None, setter=None, values=(), extract='',
                  retries=0, checks=None, discard=None):
-        super(Enumerable, self).__init__(getter, setter, get_format, retries,
-                                         checks, discard)
+        Feature.__init__(self, getter, setter, extract, retries, checks,
+                         discard)
         self.values = set(values)
         self.creation_kwargs['values'] = values
 
@@ -60,10 +60,10 @@ class Unicode(Enumerable):
     enumeration.
 
     """
-    def __init__(self, getter=None, setter=None, values=(), get_format='',
+    def __init__(self, getter=None, setter=None, values=(), extract='',
                  retries=0, checks=None, discard=None):
-        super(Unicode, self).__init__(getter, setter, values, get_format,
-                                      retries, checks, discard)
+        Enumerable.__init__(self, getter, setter, values, extract,
+                            retries, checks, discard)
 
         self.modify_behavior('post_get', self.cast_to_unicode,
                              ('cast_to_unicode', 'append'), True)
@@ -82,10 +82,10 @@ class LimitsValidated(Feature):
         provided it is used to retrieve the range from the driver at runtime.
 
     """
-    def __init__(self, getter=None, setter=None, limits=None, get_format='',
+    def __init__(self, getter=None, setter=None, limits=None, extract='',
                  retries=0, checks=None, discard=None):
-        super(LimitsValidated, self).__init__(getter, setter, get_format,
-                                              retries, checks, discard)
+        Feature.__init__(self, getter, setter, extract, retries, checks,
+                         discard)
         if limits:
             if isinstance(limits, AbstractLimitsValidator):
                 self.limits = limits
@@ -147,13 +147,13 @@ class Int(LimitsValidated, Enumerable):
 
     """
     def __init__(self, getter=None, setter=None, values=(), limits=None,
-                 get_format='', retries=0, checks=None, discard=None):
+                 extract='', retries=0, checks=None, discard=None):
         if values and not limits:
-            Enumerable.__init__(self, getter, setter, values, get_format,
+            Enumerable.__init__(self, getter, setter, values, extract,
                                 retries, checks, discard)
         else:
-            super(Int, self).__init__(getter, setter, limits, get_format,
-                                      retries, checks, discard)
+            LimitsValidated.__init__(self, getter, setter, limits, extract,
+                                     retries, checks, discard)
 
         self.modify_behavior('post_get', self.cast_to_int,
                              ('cast', 'append'), True)
@@ -172,14 +172,14 @@ class Float(LimitsValidated, Enumerable):
 
     """
     def __init__(self, getter=None, setter=None, values=(), limits=None,
-                 unit=None, get_format='', retries=0, checks=None,
+                 unit=None, extract='', retries=0, checks=None,
                  discard=None):
         if values and not limits:
-            Enumerable.__init__(self, getter, setter, values, get_format,
+            Enumerable.__init__(self, getter, setter, values, extract,
                                 retries, checks, discard)
         else:
-            super(Float, self).__init__(getter, setter, limits, get_format,
-                                        retries, checks, discard)
+            LimitsValidated.__init__(self, getter, setter, limits, extract,
+                                     retries, checks, discard)
 
         if UNIT_SUPPORT and unit:
             ureg = get_unit_registry()

--- a/tests/features/test_feature.py
+++ b/tests/features/test_feature.py
@@ -12,6 +12,7 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 from pytest import raises
+from stringparser import Parser
 
 from lantz_core.features.feature import Feature
 from lantz_core.features.util import PostGetComposer
@@ -142,8 +143,16 @@ def test_modify_behavior2():
     assert (feat._customs['post_get']['custom'][0].__func__._feat_wrapped_ ==
             meth)
 
-# Other behaviors are tested by the tests in test_has_features.py
 
-
+# Test extracting a value, when extract is a string
 def test_extract():
-    pass
+
+    feat = Feature(extract='The value is {:d}')
+    val = feat.post_get(None, 'The value is 11')
+    assert val == 11
+
+    feat = Feature(extract=Parser('The value is {:d}'))
+    val = feat.post_get(None, 'The value is 11')
+    assert val == 11
+
+# Other behaviors are tested by the tests in test_has_features.py

--- a/tests/features/test_mappings.py
+++ b/tests/features/test_mappings.py
@@ -24,6 +24,15 @@ def test_mapping():
     assert m.pre_set(None, 'Off') == 2
 
 
+def test_mapping_asymetric():
+    m = Mapping(mapping=({'On': 'ON', 'Off': 'OFF'}, {'1': 'On', '0': 'Off'}))
+    assert m.post_get(None, '1') == 'On'
+    assert m.post_get(None, '0') == 'Off'
+
+    assert m.pre_set(None, 'On') == 'ON'
+    assert m.pre_set(None, 'Off') == 'OFF'
+
+
 def test_bool():
     b = Bool(mapping={True: 1, False: 2},
              aliases={True: ['On', 'on', 'ON'], False: ['Off', 'off', 'OFF']})

--- a/tests/features/test_scalars.py
+++ b/tests/features/test_scalars.py
@@ -33,6 +33,10 @@ class TestInt(object):
         i = Int()
         assert i.post_get(None, '11') == 11
 
+    def test_post_get_with_extract(self):
+        i = Int(extract='This is the value {}')
+        assert i.post_get(None, 'This is the value 11') == 11
+
     def test_with_values(self):
         i = Int(setter=True, values=(1, 2, 3))
         assert i.pre_set(None, 2) == 2
@@ -74,11 +78,22 @@ class TestFloat(object):
         f = Float()
         assert f.post_get(None, '0.1') == 0.1
 
+    def test_post_with_extract(self):
+        f = Float(extract='This is the value {}')
+        assert f.post_get(None, 'This is the value 1.1') == 1.1
+
     @mark.skipif(UNIT_SUPPORT is False, reason="Requires Pint")
     def test_post_get_with_unit(self):
         f = Float(unit='V')
         assert hasattr(f.post_get(None, 0.1), 'magnitude')
         assert f.post_get(None, 0.1).to('mV').magnitude == 100.
+
+    @mark.skipif(UNIT_SUPPORT is False, reason="Requires Pint")
+    def test_post_get_with_extract_and_unit(self):
+        f = Float(unit='V', extract='This is the value {}')
+        val = f.post_get(None, 'This is the value 0.1')
+        assert hasattr(val, 'magnitude')
+        assert val.to('mV').magnitude == 100.
 
     def test_with_values(self):
         f = Float(setter=True, values=(1.0, 2.4, 3.1))

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -42,7 +42,7 @@ def test_customizing():
     class DecorateIP(Feature):
 
         def __init__(self, getter=True, setter=True, retries=0,
-                     get_format=None, checks=None, discard=None, dec='<br>'):
+                     extract=None, checks=None, discard=None, dec='<br>'):
             super(DecorateIP, self).__init__(getter, setter)
             self.dec = dec
 


### PR DESCRIPTION
Two minors changes (that's why I am making a single PR) : 
- Implement the missing extract method for Feature (and rename get_format arg to extract, as it was awkward).
- Allow the mapping arg of a Mapping Feature to be a tuple or list specifying the forward and reverse mapping to handle some stupid instruments.

I have added the corresponding tests. I have also dropped the use of super in all Feature derived classes as it was not playing well with the fact that the initializer signature changes. Basically for classes with a multiple inheritance both base class were called and hence some arguments was never reaching the Feature class.