### PR TITLE
Add the Action decorator class.

### DIFF
--- a/lantz_core/action.py
+++ b/lantz_core/action.py
@@ -42,7 +42,7 @@ class Action(object):
 
     checks : unicode, optional
         Booelan tests to execute before calling the function. Multiple
-        assertions can be separated with ';'. All the methods arument are
+        assertions can be separated with ';'. All the methods argument are
         available in the assertion execution namespace so one can access to the
         driver using self and to the arguments using their name (the signature
         of the wrapper is made to match the signature of the wrapped method).

--- a/lantz_core/action.py
+++ b/lantz_core/action.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+    lantz.action
+    ~~~~~~~~~~~~
+
+    Implements the Action class to wrap public driver bound methods.
+
+    :copyright: 2015 by Lantz Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+
+from functools import update_wrapper
+from types import MethodType
+
+from .unit import UNIT_SUPPORT, get_unit_registry
+
+
+class Action(object):
+    """Wraps a method with pre and post processing operations.
+
+    By default only unit processing is supported. Subclass this object to
+    customize the behavior.
+
+    All public driver methods should be decorated as an Action to make them
+    easy to identify and hence make instrospection easier.
+
+    Paremeters
+    ----------
+    units : tuple
+        Tuple of length 2 containing the return unit and the unit of each
+        passed argument. None can be used to mark that an argument should not
+        be converted. The first argument (self) should always be marked this
+        way.
+
+    """
+    def __init__(self, **kwargs):
+
+        self.kwargs = kwargs
+
+    def __call__(self, func):
+        update_wrapper(self, func)
+        self.func = self.decorate(func, self.kwargs)
+        return self
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return MethodType(self.func, obj, objtype)
+
+    def decorate(self, func, kwargs):
+        """Decorate a function according to passed arguments.
+
+        Override this function to alter how
+
+        """
+        if UNIT_SUPPORT and 'units' in kwargs:
+            return self.add_unit_support(func, kwargs['units'])
+
+        return func
+
+    def add_unit_support(self, func, units):
+        """Wrap a func using Pint to automatically convert Quantity.
+
+        """
+        ureg = get_unit_registry()
+        return ureg.wraps(*units, strict=False)(func)

--- a/lantz_core/action.py
+++ b/lantz_core/action.py
@@ -12,39 +12,45 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from functools import update_wrapper
+from past.builtins import basestring
+from functools import update_wrapper, partial
 from types import MethodType
 
-from .unit import UNIT_SUPPORT, get_unit_registry
+from funcsigs import signature
 
-# XXXX implements checks, values, limits
+from .limits import IntLimitsValidator, FloatLimitsValidator
+from .unit import UNIT_SUPPORT, get_unit_registry
+from .util import (build_checker, validate_in, validate_limits,
+                   get_limits_and_validate)
+
+
 class Action(object):
     """Wraps a method with pre and post processing operations.
 
-    By default only unit processing is supported. Subclass this object to
-    customize the behavior.
+    All parameters must be passed as keyword arguments.
 
     All public driver methods should be decorated as an Action to make them
     easy to identify and hence make instrospection easier.
 
-    Paremeters
+    Parameters
     ----------
-    units : tuple
+    units : tuple, optional
         Tuple of length 2 containing the return unit and the unit of each
         passed argument. None can be used to mark that an argument should not
         be converted. The first argument (self) should always be marked this
         way.
 
-    checks : unicode
-        Booelan tests to execute before anything else. Multiple assertion can
-        be separated with ';'. The driver can be accessed using the following
-        syntax : {driver}. The arguments can be directly accessed using their
-        name.
+    checks : unicode, optional
+        Booelan tests to execute before calling the function. Multiple
+        assertions can be separated with ';'. All the methods arument are
+        available in the assertion execution namespace so one can access to the
+        driver using self and to the arguments using their name (the signature
+        of the wrapper is made to match the signature of the wrapped method).
 
-    values : dict
+    values : dict, optional
         Dictionary mapping the arguments names to their allowed values.
 
-    limits : dict
+    limits : dict, optional
         Dictionary mapping the arguments names to their allowed limits. Limits
         can a be a tuple of length 2, or 3 (min, max, step) or the name of
         the limits to use to check the input.
@@ -52,18 +58,18 @@ class Action(object):
     Notes
     -----
     A single argument should be value checked or limit checked but not both,
-    unit conversion is performed before anything else.
+    unit conversion is performed before anything else. When limit validating
+    against a driver limits the parameter should ALWAYS be converted to the
+    same unit as the one used by the limits.
 
     """
-    __slots__ = ('func', 'kwargs', 'driver')
-
     def __init__(self, **kwargs):
 
         self.kwargs = kwargs
-        self.driver = None
 
     def __call__(self, func):
         update_wrapper(self, func)
+        self.sig = signature(func)
         self.func = self.decorate(func, self.kwargs)
         return self
 
@@ -78,8 +84,17 @@ class Action(object):
         Override this function to alter how
 
         """
+        if 'limits' in kwargs or 'values' in kwargs:
+            func = self.add_values_limits_validation(func,
+                                                     kwargs.get('values', {}),
+                                                     kwargs.get('limits', {})
+                                                     )
+
+        if 'checks' in kwargs:
+            func = self.add_checks(func, kwargs['checks'])
+
         if UNIT_SUPPORT and 'units' in kwargs:
-            return self.add_unit_support(func, kwargs['units'])
+            func = self.add_unit_support(func, kwargs['units'])
 
         return func
 
@@ -89,3 +104,93 @@ class Action(object):
         """
         ureg = get_unit_registry()
         return ureg.wraps(*units, strict=False)(func)
+
+    def add_checks(self, func, checks):
+        """Build a checker function and use it to decorate func.
+
+        Parameters
+        ----------
+        func : callable
+            Function to decorate.
+
+        checks : unicode
+            ; separated string of expression to assert.
+
+        Returns
+        -------
+        wrapped : callable
+            Function wrapped with the assertion checks.
+
+        """
+        check = build_checker(checks, self.sig)
+
+        def check_wrapper(*args, **kwargs):
+            check(*args, **kwargs)
+            return func(*args, **kwargs)
+        update_wrapper(check_wrapper, func)
+        return check_wrapper
+
+    def add_values_limits_validation(self, func, values, limits):
+        """Add arguments validation to call.
+
+        Parameters
+        ----------
+        func : callable
+            Function to decorate.
+
+        values : dict
+            Dictionary mapping the parameters name to the set of allowed
+            values.
+
+        limits : dict
+            Dictionary mapping the parameters name to the limits they must
+            abide by.
+
+        units : dict
+            Dictionary mapping
+
+        Returns
+        -------
+        wrapped : callable
+            Function wrapped with the parameters validation.
+
+        """
+        validators = {}
+        for name, vals in values.items():
+            validators[name] = partial(validate_in, name=name,
+                                       values=set(vals))
+
+        for name, lims in limits.items():
+            if name in validators:
+                msg = 'Arg %s can be limits or values validated not both'
+                raise ValueError(msg % name)
+            if isinstance(lims, (list, tuple)):
+                if any([isinstance(e, float) for e in lims]):
+                    l = FloatLimitsValidator(*lims)
+                else:
+                    l = IntLimitsValidator(*lims)
+
+                validators[name] = partial(validate_limits, limits=l,
+                                           name=name)
+
+            elif isinstance(lims, basestring):
+                validators[name] = partial(get_limits_and_validate,
+                                           limits=lims, name=name)
+
+            else:
+                msg = 'Invalid type for limits values (key {}) : {}'
+                raise TypeError(msg.format(name, type(lims)))
+
+        sig = self.sig
+
+        def wrapper(*args, **kwargs):
+
+            bound = sig.bind(*args, **kwargs).arguments
+            driver = args[0]
+            for n in validators:
+                validators[n](driver, bound[n])
+
+            return func(*args, **kwargs)
+
+        update_wrapper(wrapper, func)
+        return wrapper

--- a/lantz_core/action.py
+++ b/lantz_core/action.py
@@ -76,7 +76,7 @@ class Action(object):
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
-        return MethodType(self.func, obj, objtype)
+        return MethodType(self.func, obj)
 
     def decorate(self, func, kwargs):
         """Decorate a function according to passed arguments.

--- a/lantz_core/action.py
+++ b/lantz_core/action.py
@@ -17,7 +17,7 @@ from types import MethodType
 
 from .unit import UNIT_SUPPORT, get_unit_registry
 
-
+# XXXX implements checks, values, limits
 class Action(object):
     """Wraps a method with pre and post processing operations.
 
@@ -35,10 +35,32 @@ class Action(object):
         be converted. The first argument (self) should always be marked this
         way.
 
+    checks : unicode
+        Booelan tests to execute before anything else. Multiple assertion can
+        be separated with ';'. The driver can be accessed using the following
+        syntax : {driver}. The arguments can be directly accessed using their
+        name.
+
+    values : dict
+        Dictionary mapping the arguments names to their allowed values.
+
+    limits : dict
+        Dictionary mapping the arguments names to their allowed limits. Limits
+        can a be a tuple of length 2, or 3 (min, max, step) or the name of
+        the limits to use to check the input.
+
+    Notes
+    -----
+    A single argument should be value checked or limit checked but not both,
+    unit conversion is performed before anything else.
+
     """
+    __slots__ = ('func', 'kwargs', 'driver')
+
     def __init__(self, **kwargs):
 
         self.kwargs = kwargs
+        self.driver = None
 
     def __call__(self, func):
         update_wrapper(self, func)

--- a/lantz_core/channel.py
+++ b/lantz_core/channel.py
@@ -27,12 +27,12 @@ class Channel(SubSystem):
     ids.
 
     By default channels passes their id to their parent when they call
-    default_*_iproperty as the kwarg 'ch_id' which can be used by the parent
+    default_*_feat as the kwarg 'ch_id' which can be used by the parent
     to direct the call to the right channel.
 
     Parameters
     ----------
-    parent : HasIProp
+    parent : HasFeat
         Parent object which can be the concrete driver or a subsystem or
         channel.
     id :
@@ -53,25 +53,25 @@ class Channel(SubSystem):
         """Access parent lock."""
         return self.parent.lock
 
-    def default_get_feature(self, iprop, cmd, *args, **kwargs):
+    def default_get_feature(self, feat, cmd, *args, **kwargs):
         """Channels simply pipes the call to their parent.
 
         """
         kwargs['ch_id'] = self.id
-        return self.parent.default_get_feature(iprop, cmd, *args, **kwargs)
+        return self.parent.default_get_feature(feat, cmd, *args, **kwargs)
 
-    def default_set_feature(self, iprop, cmd, *args, **kwargs):
+    def default_set_feature(self, feat, cmd, *args, **kwargs):
         """Channels simply pipes the call to their parent.
 
         """
         kwargs['ch_id'] = self.id
-        return self.parent.default_set_feature(iprop, cmd, *args, **kwargs)
+        return self.parent.default_set_feature(feat, cmd, *args, **kwargs)
 
-    def default_check_operation(self, iprop, value, i_value, response):
+    def default_check_operation(self, feat, value, i_value, response):
         """Channels simply pipes the call to their parent.
 
         """
-        return self.parent.default_check_operation(iprop, value, i_value,
+        return self.parent.default_check_operation(feat, value, i_value,
                                                    response)
 
 AbstractChannel.register(Channel)
@@ -105,13 +105,12 @@ class ChannelContainer(object):
 
     @property
     def available(self):
-        """
+        """List the available channels.
+
         """
         return self._list()
 
     def __getitem__(self, ch_id):
-        """
-        """
         if ch_id in self._channels:
             return self._channels[ch_id]
 

--- a/lantz_core/features/feature.py
+++ b/lantz_core/features/feature.py
@@ -487,6 +487,7 @@ class Feature(property):
             self.modify_behavior('pre_set', self.set_check,
                                  ('checks', 'prepend'), True)
 
+    # XXXX rework to provide direct acces to driver, and move to util
     def _build_checker(self, check, set=False):
         """Assemble a checker function from the provided assertions.
 
@@ -494,9 +495,7 @@ class Feature(property):
         ----------
         check : unicode
             ; separated string containing boolean test to assert. '{' and '}'
-            delimit field which should be replaced by instrument state. 'value'
-            should be considered a reserved keyword available when checking
-            a set operation.
+            delimit field which should be replaced by instrument state.
 
         Returns
         -------

--- a/lantz_core/features/feature.py
+++ b/lantz_core/features/feature.py
@@ -55,9 +55,10 @@ class Feature(property):
         determine how many times to retry.
     checks : unicode or tuple(2)
         Booelan tests to execute before anything else when attempting to get or
-        set an iproperty. Multiple assertion can be separated with ';'.
-        Instrument values can be referred to using the following syntax :
-        {iprop_name}.
+        set a feature. Multiple assertion can be separated with ';'. The
+        driver driver can be accessed under the name driver and in a setter
+        the value under the name value, ie the following assertion is correct:
+        driver.voltage > value
         If a single string is provided it is used to run checks before get and
         set, if a tuple of length 2 is provided the first element is used for
         the get operation, the second for the set operation, None can be used
@@ -73,7 +74,7 @@ class Feature(property):
     Attributes
     ----------
     name : unicode
-        Name of the IProperty. This is set by the HasIProps instance and
+        Name of the Feature. This is set by the HasFeatures driver and
         should not be manipulated by user code.
     creation_kwargs : dict
         Dictionary in which all the creation args should be stored to allow
@@ -118,7 +119,7 @@ class Feature(property):
                                  ('extract', 'prepend'), True)
         self.name = ''
 
-    def pre_get(self, instance):
+    def pre_get(self, driver):
         """Hook to perform checks before querying a value from the instrument.
 
         If anything goes wrong this method should raise the corresponding
@@ -126,13 +127,13 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
 
         """
         pass
 
-    def get(self, instance):
+    def get(self, driver):
         """Acces the parent driver to retrieve the state of the instrument.
 
         By default this method falls back to calling the parent
@@ -141,7 +142,7 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
 
         Returns
@@ -151,9 +152,9 @@ class Feature(property):
             necessary it should be done in the post_get method.
 
         """
-        return instance.default_get_feature(self, self._getter)
+        return driver.default_get_feature(self, self._getter)
 
-    def post_get(self, instance, value):
+    def post_get(self, driver, value):
         """Hook to alter the value returned by the underlying driver.
 
         This can be used to convert the answer from the instrument to a more
@@ -163,7 +164,7 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
         value :
             Value as returned by the underlying driver.
@@ -176,7 +177,7 @@ class Feature(property):
         """
         return value
 
-    def pre_set(self, instance, value):
+    def pre_set(self, driver, value):
         """Hook to format the value passed to the Feature before sending it
         to the instrument.
 
@@ -187,7 +188,7 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeature
+        driver : HasFeature
             Object on which this Feature is defined.
         value :
             Value as passed by the user.
@@ -200,7 +201,7 @@ class Feature(property):
         """
         return value
 
-    def set(self, instance, value):
+    def set(self, driver, value):
         """Access the driver to actually set the instrument state.
 
         By default this method falls back to calling the parent
@@ -209,15 +210,15 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
         value :
             Object to pass to the driver method to set the value.
 
         """
-        return instance.default_set_feature(self, self._setter, value)
+        return driver.default_set_feature(self, self._setter, value)
 
-    def post_set(self, instance, value, i_value, response):
+    def post_set(self, driver, value, i_value, response):
         """Hook to perform additional action after setting a value.
 
         This can be used to check the instrument operated correctly or perform
@@ -227,7 +228,7 @@ class Feature(property):
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
         value :
             Value as passed by the user.
@@ -242,16 +243,16 @@ class Feature(property):
             Raised if the driver detects an issue.
 
         """
-        self.check_operation(self, instance, value, i_value, response)
+        self.check_operation(self, driver, value, i_value, response)
 
-    def check_operation(self, instance, value, i_value, response):
+    def check_operation(self, driver, value, i_value, response):
         """Check the instrument operated correctly.
 
         This uses the driver default_check_operation method.
 
         Parameters
         ----------
-        instance : HasFeatures
+        driver : HasFeatures
             Object on which this Feature is defined.
         value :
             Value as passed by the user.
@@ -265,8 +266,8 @@ class Feature(property):
         LantzError :
             Raised if the driver detects an issue.
         """
-        res, details = instance.default_check_operation(self, value, i_value,
-                                                        response)
+        res, details = driver.default_check_operation(self, value, i_value,
+                                                      response)
         if not res:
             mess = 'The instrument did not succeed to set {} to {} ({})'
             if details:
@@ -275,22 +276,22 @@ class Feature(property):
                 mess += '.'
             raise LantzError(mess.format(self._name, value, i_value))
 
-    def discard_cache(self, instance, value, i_value, response):
+    def discard_cache(self, driver, value, i_value, response):
         """Empty the cache of the specified values.
 
         """
-        instance.clear_cache(features=self._discard['features'])
+        driver.clear_cache(features=self._discard['features'])
         if 'limits' in self._discard:
-            instance.discard_limits(self._discard['limits'])
+            driver.discard_limits(self._discard['limits'])
 
-    def extract(self, instance, value):
+    def extract(self, driver, value):
         """Extract the return value using the extract value.
 
         """
         return self._parser(value)
 
     def clone(self):
-        """Clone the Feature by copying all the local attributes and instance
+        """Clone the Feature by copying all the local attributes and driver
         methods
 
         """
@@ -488,7 +489,7 @@ class Feature(property):
                                  ('checks', 'prepend'), True)
 
     # XXXX rework to provide direct acces to driver, and move to util
-    def _build_checker(self, check, set=False):
+    def _get(self, driver):
         """Assemble a checker function from the provided assertions.
 
         Parameters
@@ -546,78 +547,78 @@ class Feature(property):
         """Getter defined when the user provides a value for the get arg.
 
         """
-        with instance.lock:
-            cache = instance._cache
+        with driver.lock:
+            cache = driver._cache
             name = self.name
             if name in cache:
                 return cache[name]
 
-            val = get_chain(self, instance)
-            if instance.use_cache:
+            val = get_chain(self, driver)
+            if driver.use_cache:
                 cache[name] = val
 
             return val
 
-    def _set(self, instance, value):
+    def _set(self, driver, value):
         """Setter defined when the user provides a value for the set arg.
 
         """
-        with instance.lock:
-            cache = instance._cache
+        with driver.lock:
+            cache = driver._cache
             name = self.name
             if name in cache and value == cache[name]:
                 return
 
-            set_chain(self, instance, value)
-            if instance.use_cache:
+            set_chain(self, driver, value)
+            if driver.use_cache:
                 cache[name] = value
 
-    def _del(self, instance):
+    def _del(self, driver):
         """Deleter clearing the cache of the instrument for this Feature.
 
         """
-        instance.clear_cache(features=(self.name,))
+        driver.clear_cache(features=(self.name,))
 
 
-def get_chain(feat, instance):
+def get_chain(feat, driver):
     """Generic get chain for Features.
 
     """
     i = -1
-    feat.pre_get(instance)
+    feat.pre_get(driver)
 
     while i < feat._retries:
         try:
             i += 1
-            val = feat.get(instance)
+            val = feat.get(driver)
             break
-        except instance.retries_exceptions:
+        except driver.retries_exceptions:
             if i != feat._retries:
-                instance.reopen_connection()
+                driver.reopen_connection()
                 continue
             else:
                 raise
 
-    alt_val = feat.post_get(instance, val)
+    alt_val = feat.post_get(driver, val)
 
     return alt_val
 
 
-def set_chain(feat, instance, value):
+def set_chain(feat, driver, value):
     """Generic set chain for Features.
 
     """
-    i_val = feat.pre_set(instance, value)
+    i_val = feat.pre_set(driver, value)
     i = -1
     while i < feat._retries:
         try:
             i += 1
-            resp = feat.set(instance, i_val)
+            resp = feat.set(driver, i_val)
             break
-        except instance.retries_exceptions:
+        except driver.retries_exceptions:
             if i != feat._retries:
-                instance.reopen_connection()
+                driver.reopen_connection()
                 continue
             else:
                 raise
-    feat.post_set(instance, value, i_val, resp)
+    feat.post_set(driver, value, i_val, resp)

--- a/lantz_core/features/mappings.py
+++ b/lantz_core/features/mappings.py
@@ -48,10 +48,10 @@ class Mapping(Feature):
         self.modify_behavior('pre_set', self.map_value,
                              ('map', 'append'), True)
 
-    def reverse_map_value(self, instance, value):
+    def reverse_map_value(self, driver, value):
         return self._imap[value]
 
-    def map_value(self, instance, value):
+    def map_value(self, driver, value):
         return self._map[value]
 
 
@@ -79,6 +79,6 @@ class Bool(Mapping):
                     self._aliases[v] = k
         self.creation_kwargs['aliases'] = aliases
 
-    def map_value(self, instance, value):
+    def map_value(self, driver, value):
         self._aliases[value]
         return self._map[self._aliases[value]]

--- a/lantz_core/features/register.py
+++ b/lantz_core/features/register.py
@@ -58,7 +58,7 @@ class Register(Feature):
         self.modify_behavior('pre_set', self.dict_to_byte,
                              ('dict_to_byte', 'append'), True)
 
-    def byte_to_dict(self, instance, value):
+    def byte_to_dict(self, driver, value):
         """Convert the byte returned by the instrument to a dict.
 
         """
@@ -71,7 +71,7 @@ class Register(Feature):
                            for i, n in enumerate(self.names)
                            if n is not None)
 
-    def dict_to_byte(self, instance, value):
+    def dict_to_byte(self, driver, value):
         """Convert a dict into a byte value.
 
         """

--- a/lantz_core/features/scalars.py
+++ b/lantz_core/features/scalars.py
@@ -44,7 +44,7 @@ class Enumerable(Feature):
             self.modify_behavior('pre_set', self.validate_in,
                                  ('validate', 'append'), True)
 
-    def validate_in(self, instance, value):
+    def validate_in(self, driver, value):
         """Check the provided values is in the supported values.
 
         """
@@ -68,7 +68,7 @@ class Unicode(Enumerable):
         self.modify_behavior('post_get', self.cast_to_unicode,
                              ('cast_to_unicode', 'append'), True)
 
-    def cast_to_unicode(self, instance, value):
+    def cast_to_unicode(self, driver, value):
         return ustr(value)
 
 
@@ -158,7 +158,7 @@ class Int(LimitsValidated, Enumerable):
         self.modify_behavior('post_get', self.cast_to_int,
                              ('cast', 'append'), True)
 
-    def cast_to_int(self, instance, value):
+    def cast_to_int(self, driver, value):
         """Cast the value returned by the instrument to an int.
 
         """
@@ -199,7 +199,7 @@ class Float(LimitsValidated, Enumerable):
         self.modify_behavior('post_get', self.cast_to_float,
                              ('cast', 'append'), True)
 
-    def cast_to_float(self, instance, value):
+    def cast_to_float(self, driver, value):
         """Cast the value returned by the instrument to float or Quantity.
 
         """
@@ -210,7 +210,7 @@ class Float(LimitsValidated, Enumerable):
         else:
             return fval
 
-    def convert(self, instance, value):
+    def convert(self, driver, value):
         """Convert unit.
 
         """

--- a/lantz_core/features/util.py
+++ b/lantz_core/features/util.py
@@ -16,10 +16,10 @@ from functools import update_wrapper
 
 
 def wrap_custom_feat_method(meth, feat):
-    """ Wrap a HasFeature method to make it an instance method of a Feature.
+    """ Wrap a HasFeature method to make it an driver method of a Feature.
 
     This is necessary so that users can define overriding method in a natural
-    way in the HasFeatures subclass assuming that the instance object will be
+    way in the HasFeatures subclass assuming that the driver object will be
     passed as first argument and the Feature object as second when in reality
     it will be the other way round due to python binding mechanism.
 
@@ -48,8 +48,8 @@ def wrap_custom_feat_method(meth, feat):
 
     # Wrap if necessary the function to match the argument order.
     if not hasattr(meth, '_feat_wrapped_'):
-        def wrapper(iprop, instance, *args, **kwargs):
-            return wrapped(instance, iprop, *args, **kwargs)
+        def wrapper(feat, driver, *args, **kwargs):
+            return wrapped(driver, feat, *args, **kwargs)
 
         update_wrapper(wrapper, wrapped)
         wrapper._feat_wrapped_ = wrapped

--- a/lantz_core/has_features.py
+++ b/lantz_core/has_features.py
@@ -42,7 +42,7 @@ LIMITS_PREFIX = '_limits_'
 
 
 class set_feat(object):
-    """Placeholder use to alter a feature in a subclass.
+    """Placeholder used to alter a feature in a subclass.
 
     This can be used to lightly alter a Feature defined on a parent class
     by for example changing the retries or the getter but without
@@ -411,9 +411,9 @@ class HasFeaturesMeta(type):
                     and issubclass(base, AbstractHasFeatures):
                 base_feats.update(base.__feats__)
 
-        # The set of iprops which live on this class as opposed to a
+        # The set of features which live on this class as opposed to a
         # base class. This enables the code which hooks up the various
-        # static behaviours to only clone a iprops when necessary.
+        # static behaviours to only clone a feature when necessary.
         owned_feats = set(feats.keys())
 
         all_feats = dict(base_feats)
@@ -475,14 +475,11 @@ class HasFeaturesMeta(type):
 
 
 class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
-    """ Base class for objects using the IProperties mechanisms.
+    """Base class for objects using the Features mechanisms.
 
     """
-    #: Tuple of iproperties names which shoulb be cached by default.
-    caching_permissions = ()
-
     #: Tuple of exception to consider when securing a communication (either via
-    #: secure_communication decorator or for iproperties with a non zero
+    #: secure_communication decorator or for features with a non zero
     #: retries value)
     retries_exceptions = ()
 
@@ -518,7 +515,7 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
 
         Returns
         -------
-        iprop : Feature
+        feat : Feature
             Matching Feature object
 
         """
@@ -699,12 +696,12 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
             '''This method is used to reopen a connection whose state
             is suspect, for example the last message sent did not
             go through, and should be implemented by classes
-            subclassing HasIProps'''),
+            subclassing HasFeatures'''),
             80)
         raise NotImplementedError(message)
 
     def default_get_feature(self, feat, cmd, *args, **kwargs):
-        """Method used by default by the IProperty to retrieve a value from an
+        """Method used by default by the Feature to retrieve a value from an
         instrument.
 
         Parameters
@@ -727,7 +724,7 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
         raise NotImplementedError(mess)
 
     def default_set_feature(self, feat, cmd, *args, **kwargs):
-        """Method used by default by the IProperty to set an instrument value.
+        """Method used by default by the Feature to set an instrument value.
 
         Parameters
         ----------
@@ -749,7 +746,7 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
         raise NotImplementedError(mess)
 
     def default_check_operation(self, feat, value, i_value, state=None):
-        """Method used by default by the IProperty to check the instrument
+        """Method used by default by the Feature to check the instrument
         operation.
 
         Parameters

--- a/lantz_core/subsystem.py
+++ b/lantz_core/subsystem.py
@@ -58,23 +58,23 @@ class SubSystem(with_metaclass(DeclarationMeta, HasFeatures)):
         """
         self.parent.reopen_connection()
 
-    def default_get_feature(self, iprop, cmd, *args, **kwargs):
+    def default_get_feature(self, feat, cmd, *args, **kwargs):
         """Subsystems simply pipes the call to their parent.
 
         """
-        return self.parent.default_get_feature(iprop, cmd, *args, **kwargs)
+        return self.parent.default_get_feature(feat, cmd, *args, **kwargs)
 
-    def default_set_feature(self, iprop, cmd, *args, **kwargs):
+    def default_set_feature(self, feat, cmd, *args, **kwargs):
         """Subsystems simply pipes the call to their parent.
 
         """
-        return self.parent.default_set_feature(iprop, cmd, *args, **kwargs)
+        return self.parent.default_set_feature(feat, cmd, *args, **kwargs)
 
-    def default_check_operation(self, iprop, value, i_value, response):
+    def default_check_operation(self, feat, value, i_value, response):
         """Subsystems simply pipes the call to their parent.
 
         """
-        return self.parent.default_check_operation(iprop, value, i_value,
+        return self.parent.default_check_operation(feat, value, i_value,
                                                    response)
 
 AbstractSubSystem.register(SubSystem)

--- a/lantz_core/util.py
+++ b/lantz_core/util.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+    lantz_core.util
+    ~~~~~~~~~~~~~~~
+
+    :copyright: 2015 by Lantz Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+from future.utils import exec_
+from future.builtins import str
+
+
+def build_checker(checks, signature, ret=''):
+    """Assemble a checker function from the provided assertions.
+
+    Parameters
+    ----------
+    checks : unicode
+        ; separated string containing boolean test to assert. '{' and '}'
+        delimit field which should be replaced by instrument state.
+
+    signature : unicode or funcsigs.Signature
+        Signature of the check function to build.
+
+    ret : unicode
+        Name of the parameters to return. This string will be preceded by a
+        return statement.
+
+    Returns
+    -------
+    checker : function
+        Function to use
+
+    """
+    func_def = 'def check' + str(signature) + ':\n'
+    assertions = checks.split(';')
+    for assertion in assertions:
+        # XXXX use AST manipulation to provide more infos about assertion
+        # failure. Take inspiration from pytest.assertions.rewrite.
+        a_mess = '"Assertion %s failed"' % assertion
+        func_def += '    assert ' + assertion + ', ' + a_mess + '\n'
+
+    if ret:
+        func_def += '    return %s' % ret
+
+    loc = {}
+    exec_(func_def, globals(), loc)
+    return loc['check']
+
+
+# The next three function take all driver as first argument for homogeneity.
+
+def validate_in(driver, value, values, name):
+    """Assert that a value is in a container.
+
+    """
+    if value not in values:
+        mess = 'Allowed value for {} are {}, {} not allowed'
+        raise ValueError(mess.format(name, values, value))
+
+
+def validate_limits(driver, value, limits, name):
+    """Make sure a value is in the given range.
+
+    """
+    if not limits.validate(value):
+        raise_limits_error(name, value, limits)
+    else:
+        return value
+
+
+def get_limits_and_validate(driver, value, limits, name):
+    """Query the current limits from the driver and validate the values.
+
+    """
+    limits = driver.get_limits(limits)
+    return validate_limits(driver, value, limits, name)
+
+
+def raise_limits_error(name, value, limits):
+    """Raise a value when the limits validation fails.
+
+    """
+    mess = 'The provided value {} is out of bound for {}.'
+    mess = mess.format(value, name)
+    if limits.minimum:
+        mess += ' Minimum {}.'.format(limits.minimum)
+    if limits.maximum:
+        mess += ' Maximum {}.'.format(limits.maximum)
+    if limits.step:
+        mess += ' Step {}.'.format(limits.step)
+    raise ValueError(mess)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ language to wrap existing drivers and DLLs.''',
                 'lantz_core.features'],
     requires = ['numpy',
                 'future',
-                'pyvisa'],
+                'pyvisa',
+                'funcsigs'],
 )
-

--- a/tests/features/test_feature.py
+++ b/tests/features/test_feature.py
@@ -81,9 +81,10 @@ def test_feature_checkers():
 
         aux = 1
         feat = Feature(True)
-        feat_ch = Feature(True, True, checks='{aux}==1; {feat} is True')
-        feat_gch = Feature(True, True, checks=('{aux}==1', None))
-        feat_sch = Feature(True, True, checks=(None, '{aux}==1'))
+        feat_ch = Feature(True, True,
+                          checks='driver.aux==1; driver.feat is True')
+        feat_gch = Feature(True, True, checks=('driver.aux==1', None))
+        feat_sch = Feature(True, True, checks=(None, 'driver.aux==1'))
 
     assert hasattr(AuxParent.feat_ch, 'get_check')
     assert hasattr(AuxParent.feat_ch, 'set_check')
@@ -115,7 +116,7 @@ def test_feature_checkers():
 
 def test_clone():
 
-    feat_ch = Feature(True, True, checks='{aux}==1; {feat} is True')
+    feat_ch = Feature(True, True, checks='driver.aux==1; driver.feat is True')
     new = feat_ch.clone()
     assert feat_ch.pre_get is not new.pre_get
     assert feat_ch._customs is not new._customs

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -11,15 +11,17 @@
 """
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
-from pytest import mark
+
+from pytest import mark, raises
 
 from lantz_core.action import Action
+from lantz_core.limits import IntLimitsValidator
 from lantz_core.unit import UNIT_SUPPORT, get_unit_registry
 from .testing_tools import DummyParent
 
 
-def test_action_without_unit():
-    """Test defining an action not using units conversions.
+def test_naked_action():
+    """Test defining a simple action.
 
     """
     class Dummy(DummyParent):
@@ -32,6 +34,98 @@ def test_action_without_unit():
 
     dummy = Dummy()
     assert dummy.test() is Dummy
+
+
+def test_values_action():
+    """Test defining an action with values validation.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action(values={'a': (1, 2, 3)})
+        def test(self, a, b):
+            return a * b
+
+    dummy = Dummy()
+    assert dummy.test(1, 5) == 5
+    with raises(ValueError):
+        dummy.test(5, 2)
+
+
+def test_limits_action1():
+    """Test defining an action with integer limits validation.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action(limits={'b': (1, 10, 2)})
+        def test(self, a, b):
+            return a
+
+    dummy = Dummy()
+    assert dummy.test(1, 1) == 1
+    with raises(ValueError):
+        dummy.test(2,  2)
+
+
+def test_limits_action2():
+    """Test defining an action with floating limits validation.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action(limits={'b': (1.0, 10.0, 0.1)})
+        def test(self, a, b):
+            return a
+
+    dummy = Dummy()
+    assert dummy.test(1, 1)
+    with raises(ValueError):
+        dummy.test(2,  1.05)
+
+
+def test_limits_action3():
+    """Test defining an action getting the limits from the driver.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action(limits={'b': 'c'})
+        def test(self, a, b):
+            return a
+
+        def _limits_c(self):
+            return IntLimitsValidator(1, 10, 2)
+
+    dummy = Dummy()
+    assert dummy.test(1, 1)
+    with raises(ValueError):
+        dummy.test(2,  2)
+
+
+def test_limits_action4():
+    """Test defining an action with the wrong type of limits.
+
+    """
+    with raises(TypeError):
+        class Dummy(DummyParent):
+
+            @Action(limits={'b': 1})
+            def test(self, a, b):
+                return a
+
+
+def test_action_with_overlapping_limits_and_values():
+    """Test defining an action validating the same parameter using values and
+    limits.
+
+    """
+    with raises(ValueError):
+        class Dummy(DummyParent):
+
+            @Action(limits={'b': (1, 10, 2)}, values={'b': (1, 2, 3)})
+            def test(self, a, b):
+                return a
 
 
 @mark.skipif(UNIT_SUPPORT is False, reason="Requires Pint")

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+    tests.test_action
+    ~~~~~~~~~~~~~~~~~
+
+    Module dedicated to testing action behavior.
+
+    :copyright: 2015 by Lantz Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+from pytest import mark
+
+from lantz_core.action import Action
+from lantz_core.unit import UNIT_SUPPORT, get_unit_registry
+from .testing_tools import DummyParent
+
+
+def test_action_without_unit():
+    """Test defining an action not using units conversions.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action()
+        def test(self):
+            return type(self)
+
+    assert isinstance(Dummy.test, Action)
+
+    dummy = Dummy()
+    assert dummy.test() is Dummy
+
+
+@mark.skipif(UNIT_SUPPORT is False, reason="Requires Pint")
+def test_action_with_unit():
+    """Test defining an action not using units conversions.
+
+    """
+    class Dummy(DummyParent):
+
+        @Action(units=('ohm*A', (None, 'ohm', 'A')))
+        def test(self, r, i):
+            return r*i
+
+    assert isinstance(Dummy.test, Action)
+
+    dummy = Dummy()
+    assert dummy.test(2, 3) == get_unit_registry().parse_expression('6 V')

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -13,9 +13,11 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 from pytest import raises
 
-from lantz_core.has_features import subsystem, set_feat, channel, HasFeatures
+from lantz_core.has_features import (subsystem, set_feat, channel, HasFeatures,
+                                     set_action)
 from lantz_core.subsystem import SubSystem
 from lantz_core.channel import Channel
+from lantz_core.action import Action
 from lantz_core.features.feature import Feature
 from lantz_core.features.util import (append, prepend, add_after, add_before,
                                       replace)
@@ -188,7 +190,7 @@ def test_clone_if_needed():
 
 class ToCustom(DummyParent):
 
-    feat = Feature(getter=True, checks='{aux} is True')
+    feat = Feature(getter=True, checks='driver.aux is True')
 
     def __init__(self):
         super(ToCustom, self).__init__()
@@ -402,6 +404,28 @@ def test_copying_custom_behavior3():
     driver.aux = False
     driver.feat
     assert driver.custom_called == 3
+
+
+# --- Test customizing Action -------------------------------------------------
+
+def test_set_action():
+    """Test customizing an action using set_action.
+
+    """
+    class C1(DummyParent):
+
+        @Action()
+        def test(self, c):
+            return c
+
+    class C2(C1):
+
+        test = set_action(values={'c': (1, 2)})
+
+    assert not C1().test(0)
+    assert C2().test(1)
+    with raises(ValueError):
+        assert C2().test(0)
 
 
 # --- Test declaring subsystems -----------------------------------------------


### PR DESCRIPTION
Add the Action class to use as a decorator. The class can be easily customized by overriding the decorate method. By default only the units keywords is used and can be specified to use wraps from pint.UnitRegistry if pint is available.
The class must always be instantiate before using it as a decorator ie : 
``` python
@Action()
def test(self):
    pass
```
not 
``` python
@Action
def test(self):
    pass
```