### PR TITLE
Static channels

### DIFF
--- a/lantz_core/channel.py
+++ b/lantz_core/channel.py
@@ -96,12 +96,15 @@ class ChannelContainer(object):
 
     """
 
-    def __init__(self, cls, parent, name, list_available):
+    def __init__(self, cls, parent, name, available):
         self._cls = cls
         self._channels = {}
         self._name = name
         self._parent = parent
-        self._list = getattr(parent, list_available)
+        if isinstance(available, (tuple, list)):
+            self._list = lambda: available
+        else:
+            self._list = getattr(parent, available)
 
     @property
     def available(self):

--- a/lantz_core/has_features.py
+++ b/lantz_core/has_features.py
@@ -411,11 +411,10 @@ class HasFeaturesMeta(type):
                 ch_cls = make_cls_from_subpart(name, part_name,
                                                part, inherited_ch[k][0],
                                                docs)
+
+                # Must be valid otherwise parent declaration would be messed up
                 available = (part._available_ if part._available_ else
                              inherited_ch[k][1])
-                if not available:
-                    msg = 'No way to identify channels defined for {}'
-                    raise ValueError(msg.format(k))
                 channels[part_name] = (ch_cls, available)
 
             else:

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -16,7 +16,7 @@ from lantz_core.has_features import channel
 from .testing_tools import DummyParent
 
 
-class ChParent(DummyParent):
+class ChParent1(DummyParent):
 
     ch = channel('_list_ch')
 
@@ -24,9 +24,14 @@ class ChParent(DummyParent):
         return (1, )
 
 
+class ChParent2(DummyParent):
+
+    ch = channel(('a',))
+
+
 def test_ch_d_get():
 
-    a = ChParent()
+    a = ChParent1()
     ch = a.ch[1]
     ch.default_get_feature(None, 'Test', 1, a=2)
     assert a.d_get_called == 1
@@ -37,31 +42,31 @@ def test_ch_d_get():
 
 def test_ch_d_set():
 
-    a = ChParent()
-    ch = a.ch[1]
+    a = ChParent2()
+    ch = a.ch['a']
     ch.default_set_feature(None, 'Test', 1, a=2)
     assert a.d_set_called == 1
     assert a.d_set_cmd == 'Test'
     assert a.d_set_args == (1,)
-    assert a.d_set_kwargs == {'id': 1, 'a': 2}
+    assert a.d_set_kwargs == {'id': 'a', 'a': 2}
 
 
 def test_ch_d_check():
 
-    a = ChParent()
+    a = ChParent1()
     ch = a.ch[1]
     ch.default_check_operation(None, None, None, None)
     assert a.d_check_instr == 1
 
 
 def test_ch_lock():
-    a = ChParent()
+    a = ChParent1()
     ch = a.ch[1]
     assert ch.lock is a.lock
 
 
 def test_ch_reop():
-    a = ChParent()
+    a = ChParent1()
     ch = a.ch[1]
     ch.reopen_connection()
     assert a.ropen_called == 1

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -520,6 +520,28 @@ def test_channel_declaration1():
     assert d.ch[1] is ch
 
 
+def test_channel_declaration2():
+
+    class DeclareChannel(DummyParent):
+
+        ch = channel((1,))
+
+    class OverrideChannel(DeclareChannel):
+
+        ch = channel()
+
+        with ch:
+            ch.test = Feature(getter=True)
+
+            @ch
+            def _get_test(self, iprop):
+                return 'This is a test'
+
+    d = OverrideChannel()
+    assert d.ch.available == (1,)
+    assert d.ch[1].test == 'This is a test'
+
+
 def test_def_check():
     with raises(NotImplementedError):
         HasFeatures().default_check_operation(None, None, None)


### PR DESCRIPTION
This allow to declare directly the channel ids when declaring the driver (as a list or tuple) which makes sense when the number of channel is fixed. It also allow to use the parent class channel ids when overriding a channel which is a nice convenience.

based on #12 