### PR TITLE
Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 env:
   - PINT="N" PYVISA='N'

--- a/lantz_core/backends/visa.py
+++ b/lantz_core/backends/visa.py
@@ -399,7 +399,7 @@ class VisaMessageDriver(BaseVisaDriver):
     def read_status_byte(self):
         return byte_to_dict(self._resource.read_stb(), self.STATUS_BYTE)
 
-    def default_get_feature(self, iprop, cmd, *args, **kwargs):
+    def default_get_feature(self, feat, cmd, *args, **kwargs):
         """Query the value using the provided command.
 
         The command is formatted using the provided args and kwargs before
@@ -408,7 +408,7 @@ class VisaMessageDriver(BaseVisaDriver):
         """
         return self._resource.query(cmd.format(*args, **kwargs))
 
-    def default_set_feature(self, iprop, cmd, *args, **kwargs):
+    def default_set_feature(self, feat, cmd, *args, **kwargs):
         """Set the iproperty value of the instrument.
 
         The command is formatted using the provided args and kwargs before

--- a/lantz_core/base_channel.py
+++ b/lantz_core/base_channel.py
@@ -91,29 +91,40 @@ class ChannelContainer(object):
     name : unicode
         Name of the channel subpart on the parent.
 
-    list_available : unicode
-        Name of the parent method to use to query the available channels.
+    list_available : callable
+        Function to call to query the list of available channels.
+
+    aliases : dict
+        Dict mapping aliases names to the real channel id to use.
 
     """
 
-    def __init__(self, cls, parent, name, available):
+    def __init__(self, cls, parent, name, list_available, aliases):
         self._cls = cls
         self._channels = {}
         self._name = name
         self._parent = parent
-        if isinstance(available, (tuple, list)):
-            self._list = lambda: available
-        else:
-            self._list = getattr(parent, available)
+        self._aliases = aliases
+        self._list = list_available
 
     @property
     def available(self):
         """List the available channels.
 
         """
-        return self._list()
+        return self._list(self._parent)
+
+    @property
+    def aliases(self):
+        """List the aliases.
+
+        """
+        return self._aliases.copy()
 
     def __getitem__(self, ch_id):
+        if ch_id in self._aliases:
+            ch_id = self._aliases[ch_id]
+
         if ch_id in self._channels:
             return self._channels[ch_id]
 

--- a/lantz_core/base_channel.py
+++ b/lantz_core/base_channel.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    lantz_core.channel
-    ~~~~~~~~~~~~~
+    lantz_core.base_channel
+    ~~~~~~~~~~~~~~~~~~~~~~~
 
     Channel simplifies the writing of instrument implementing channel specific
     behaviours.
@@ -14,7 +14,7 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from .has_features import AbstractChannel
-from .subsystem import SubSystem
+from .base_subsystem import SubSystem
 
 
 class Channel(SubSystem):

--- a/lantz_core/base_subsystem.py
+++ b/lantz_core/base_subsystem.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    lantz_core.subsystem
-    ~~~~~~~~~~~~~~~~~~~~
+    lantz_core.base_subsystem
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Subsystems can be used to give a hierarchical organisation to a driver.
 

--- a/lantz_core/features/__init__.py
+++ b/lantz_core/features/__init__.py
@@ -15,5 +15,8 @@ from __future__ import (division, unicode_literals, print_function,
 from .bool import Bool
 from .scalars import Unicode, Int, Float
 from .register import Register
+from .alias import Alias
+from .util import constant, conditional
 
-__all__ = ['Bool', 'Unicode', 'Int', 'Float', 'Register']
+__all__ = ['Bool', 'Unicode', 'Int', 'Float', 'Register', 'Alias', 'constant',
+           'conditional']

--- a/lantz_core/features/alias.py
+++ b/lantz_core/features/alias.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+    lantz_core.features.alias
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Feature whose value is mapped to another Feature.
+
+    :copyright: 2015 by Lantz Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+
+from types import MethodType
+
+from future.utils import exec_
+
+from .feature import Feature, get_chain, set_chain
+
+
+GET_DEF =\
+"""def get(self, driver):
+    return {}
+
+"""
+
+
+SET_DEF =\
+"""def set(self, driver, value):
+    {} = value
+
+"""
+
+
+class Alias(Feature):
+    """Feature whose value is mapped to another Feature.
+
+    """
+
+    def __init__(self, alias, settable=None):
+
+        super(Alias, self).__init__(True, settable)
+
+        accessor = 'driver.' + '.'.join([p if p else 'parent'
+                                         for p in alias.split('.')])
+
+        defs = GET_DEF.format(accessor)
+        if settable:
+            defs += '\n' + SET_DEF.format(accessor)
+
+        loc = {}
+        exec_(defs, globals(), loc)
+
+        self.get = MethodType(loc['get'], self)
+        if settable:
+            self.set = MethodType(loc['set'], self)
+
+    def post_set(self, driver, value, i_value, response):
+        """Re-implemented here as an Alias does not need to do anaything
+        by default.
+
+        """
+        pass
+
+    # =========================================================================
+    # --- Private API ---------------------------------------------------------
+    # =========================================================================
+
+    def _get(self, driver):
+        """Re-implemented so that Alias never use the cache.
+
+        """
+        with driver.lock:
+            return get_chain(self, driver)
+
+    def _set(self, driver, value):
+        """Re-implemented so that Alias never uses the cache.
+
+        """
+        with driver.lock:
+            set_chain(self, driver, value)

--- a/lantz_core/features/register.py
+++ b/lantz_core/features/register.py
@@ -46,8 +46,7 @@ class Register(Feature):
             # Makes sure every key is unique by using the bit index if None is
             # found
             for i, n in enumerate(names[:]):
-                if n is None:
-                    names[i] = i
+                names[i] = n or i
 
         self.names = tuple(names)
         self.creation_kwargs['names'] = names

--- a/lantz_core/has_features.py
+++ b/lantz_core/has_features.py
@@ -238,11 +238,11 @@ def make_cls_from_subpart(parent_name, part_name, part, base, docs):
         bases = part._bases_
         if (isinstance(part, subsystem) and
                 (not bases or not issubclass(bases[0], AbstractSubSystem))):
-            from .subsystem import SubSystem
+            from .base_subsystem import SubSystem
             bases = tuple([SubSystem] + list(bases))
         elif (isinstance(part, channel) and
                 (not bases or not issubclass(bases[0], AbstractChannel))):
-            from .channel import Channel
+            from .base_channel import Channel
             bases = tuple([Channel] + list(bases))
 
     # Extract the docstring specific to this subpart.
@@ -527,7 +527,6 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
 
         self._cache = {}
         self._limits_cache = {}
-        self._proxies = {}
 
         subsystems = self.__subsystems__
         channels = self.__channels__
@@ -541,7 +540,7 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
 
         # Creating a channel container for each kind of declared channels.
         for ch, (cls, listing) in channels.items():
-            from .channel import ChannelContainer
+            from .base_channel import ChannelContainer
             ch_holder = ChannelContainer(cls, self, ch, listing)
             setattr(self, ch, ch_holder)
 
@@ -569,12 +568,12 @@ class HasFeatures(with_metaclass(HasFeaturesMeta, object)):
         ----------
         subsystems : bool, optional
             Whether or not to clear the subsystems. This argument is used only
-            if properties is None.
+            if features is None.
         channels : bool, optional
             Whether or not to clear the channels. This argument is used only
-            if properties is None.
+            if features is None.
         features : iterable of str, optional
-            Name of the properties whose cache should be cleared. Dotted names
+            Name of the features whose cache should be cleared. Dotted names
             can be used to access subsystems and channels. When accessing
             channels the cache of all instances is cleared. All caches
             will be cleared if not specified.

--- a/lantz_core/has_features.py
+++ b/lantz_core/has_features.py
@@ -434,7 +434,6 @@ class HasFeaturesMeta(type):
                              else inherited_ch[k][1])
                 aliases = (part._ch_aliases_ if part._ch_aliases_ else
                            inherited_ch[k][2])
-                print(k, available, aliases)
                 channels[part_name] = (ch_cls, available, aliases)
 
             else:

--- a/lantz_core/unit.py
+++ b/lantz_core/unit.py
@@ -70,3 +70,34 @@ def get_unit_registry():
         UNIT_REGISTRY = UnitRegistry()
 
     return UNIT_REGISTRY
+
+
+def to_float(value):
+    """Convert a value which could be a Quantity to a float.
+
+    """
+    try:
+        return value.m if UNIT_SUPPORT else value
+    except AttributeError:
+        return value
+
+
+def to_quantity(value, unit):
+    """Turn a value into a Quantity with the given unit.
+
+    This is a no-op if unit support is not available.
+
+    Parameters
+    ----------
+    value : float
+        Value to cast.
+
+    unit : unicode
+        Unit of the quantity to create.
+
+    """
+    if UNIT_SUPPORT:
+        ureg = get_unit_registry()
+        value *= ureg.parse_expression(unit)
+
+    return value

--- a/lantz_core/util.py
+++ b/lantz_core/util.py
@@ -23,8 +23,7 @@ def build_checker(checks, signature, ret=''):
     Parameters
     ----------
     checks : unicode
-        ; separated string containing boolean test to assert. '{' and '}'
-        delimit field which should be replaced by instrument state.
+        ; separated string containing boolean test to assert.
 
     signature : unicode or funcsigs.Signature
         Signature of the check function to build.
@@ -116,9 +115,8 @@ def byte_to_dict(byte, mapping):
     def bit_conversion(x, i):
             return bool(x & (1 << i))
 
-    return OrderedDict((n, bit_conversion(byte, i))
-                       for i, n in enumerate(mapping)
-                       if n is not None)
+    return OrderedDict((n or i, bit_conversion(byte, i))
+                       for i, n in enumerate(mapping))
 
 
 def dict_to_byte(values, mapping):

--- a/tests/features/test_alias.py
+++ b/tests/features/test_alias.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+    tests.features.test_alias
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for the tools to customize feature and help in their writings.
+
+    :copyright: 2015 by Lantz Authors, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+
+import pytest
+
+from lantz_core.has_features import subsystem
+from lantz_core.features import Bool
+from lantz_core.features.alias import Alias
+
+from ..testing_tools import DummyParent
+
+
+@pytest.fixture
+def tester():
+    class AliasTester(DummyParent):
+
+        state = Bool(True, True, mapping={True: True, False: False})
+        _state = False
+
+        r_alias = Alias('state')
+
+        sub = subsystem()
+
+        with sub as s:
+            s.rw_alias = Alias('.state', True)
+
+        def _get_state(self, feat):
+            return self._state
+
+        def _set_state(self, feat, value):
+            self._state = value
+
+    return AliasTester()
+
+
+def test_alias_on_same_level(tester):
+
+    assert tester.r_alias is False
+    tester.state = True
+    assert tester.r_alias is True
+
+    with pytest.raises(AttributeError):
+        tester.r_alias = False
+
+
+def test_alias_on_parent(tester):
+
+    assert tester.sub.rw_alias is False
+    tester.state = True
+    assert tester.sub.rw_alias is True
+
+    tester.sub.rw_alias = False
+    assert tester.state is False

--- a/tests/features/test_feature.py
+++ b/tests/features/test_feature.py
@@ -15,7 +15,7 @@ from pytest import raises
 from stringparser import Parser
 
 from lantz_core.features.feature import Feature, get_chain, set_chain
-from lantz_core.features.util import PostGetComposer
+from lantz_core.features.util import PostGetComposer, constant, conditional
 from lantz_core.errors import LantzError
 from ..testing_tools import DummyParent
 
@@ -110,6 +110,36 @@ def test_del():
     assert driver.d_set_called == 2
 
 
+def test_getter_factory():
+    """Test using a getter factory.
+
+    """
+    class FactoryTester(DummyParent):
+
+        feat = Feature(constant('Test'))
+
+    driver = FactoryTester()
+    assert driver.feat == 'Test'
+
+
+def test_setter_factory():
+    """Test using a factory setter.
+
+    """
+    class FactoryTester(DummyParent):
+
+        state = False
+
+        feat = Feature(setter=conditional('1 if driver.state else 2', True))
+
+    driver = FactoryTester()
+    driver.feat = None
+    assert driver.d_set_cmd == 2
+    driver.state = True
+    driver.feat = True
+    assert driver.d_set_cmd == 1
+
+
 def test_get_chain():
     """Test the get_chain capacity to iterate in case of driver issue.
 
@@ -128,6 +158,7 @@ def test_get_chain():
 
 def test_set_chain():
     """Test the set_chain capacity to iterate in case of driver issue.
+
     """
     driver = DummyParent()
     driver.retries_exceptions = (LantzError,)

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -29,6 +29,11 @@ class ChParent2(DummyParent):
     ch = channel(('a',))
 
 
+class ChParent3(DummyParent):
+
+    ch = channel(('a',), aliases={0: 'a'})
+
+
 def test_ch_d_get():
 
     a = ChParent1()
@@ -70,3 +75,10 @@ def test_ch_reop():
     ch = a.ch[1]
     ch.reopen_connection()
     assert a.ropen_called == 1
+
+
+def test_listing_aliases():
+    a = ChParent3()
+    aliases = a.ch.aliases
+    assert a.ch.aliases is not aliases
+    assert a.ch.aliases == aliases

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -14,8 +14,8 @@ from __future__ import (division, unicode_literals, print_function,
 from pytest import raises
 
 from lantz_core.has_features import (subsystem, set_feat, channel, set_action)
-from lantz_core.subsystem import SubSystem
-from lantz_core.channel import Channel
+from lantz_core.base_subsystem import SubSystem
+from lantz_core.base_channel import Channel
 from lantz_core.action import Action
 from lantz_core.features.feature import Feature
 from lantz_core.features.util import (append, prepend, add_after, add_before,

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -614,6 +614,28 @@ def test_channel_declaration3():
             ch = channel()
 
 
+def test_channel_declaration4():
+    """Test declaring channel aliases.
+
+    """
+
+    class DeclareChannel(DummyParent):
+
+        ch = channel((1,))
+
+    class OverrideChannel(DeclareChannel):
+
+        ch = channel(aliases={'Test': 1})
+
+    class OverrideChannel2(OverrideChannel):
+
+        ch = channel()
+
+    d = OverrideChannel2()
+    assert tuple(d.ch.available) == (1, 'Test')
+    assert d.ch['Test'].id == 1
+
+
 # --- Test cache handling -----------------------------------------------------
 
 class TestHasFeaturesCache(object):

--- a/tests/test_has_features.py
+++ b/tests/test_has_features.py
@@ -461,6 +461,7 @@ def test_subsystem_declaration1():
     assert DeclareSubsystem.sub_test.__doc__ == 'Subsystem docstring'
     d = DeclareSubsystem()
     assert d.__subsystems__
+    assert type(d.sub_test) is DeclareSubsystem.sub_test
     assert isinstance(d.sub_test, SubSystem)
 
 
@@ -573,6 +574,7 @@ def test_channel_declaration1():
 
     d = DeclareChannel()
     assert d.__channels__
+    assert d.ch is not DeclareChannel.ch
     assert d.ch.available == (1,)
     ch = d.ch[1]
     assert isinstance(ch, Dummy)

--- a/tests/test_subsytem.py
+++ b/tests/test_subsytem.py
@@ -13,7 +13,7 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from lantz_core.has_features import subsystem
-from lantz_core.subsystem import SubSystem
+from lantz_core.base_subsystem import SubSystem
 from .testing_tools import DummyParent
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -51,4 +51,5 @@ def test_converters(teardown):
 
     """
     val = 1.0
+    assert to_float(val) == val
     assert to_float(to_quantity(val, 'A')) == val

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,7 +14,8 @@ from __future__ import (division, unicode_literals, print_function,
 from pytest import raises, yield_fixture, mark
 
 from lantz_core import unit
-from lantz_core.unit import set_unit_registry, get_unit_registry
+from lantz_core.unit import (set_unit_registry, get_unit_registry,
+                             to_float, to_quantity)
 
 try:
     from pint import UnitRegistry
@@ -43,3 +44,11 @@ def test_reset_unit_registry(teardown):
     set_unit_registry(ureg)
     with raises(ValueError):
         set_unit_registry(ureg)
+
+
+def test_converters(teardown):
+    """Test to_quantity and to_float utility functions.
+
+    """
+    val = 1.0
+    assert to_float(to_quantity(val, 'A')) == val


### PR DESCRIPTION
This PR adds some tools I needed when working on the DC sources (https://github.com/LabPy/lantz_drivers/pull/4) : 
- Alias feature : allow to reference a Feature from a different subsystem. This can be useful when we need a Feature in a channel (because of the standard) but the actual setting is global (see Keysight E3631A).
- **NEW** channel aliases : allow to map custom channel id to instrument channel id (allowing to use 0, 1, 2 even if the instrument ids are names)
- getter and setter factories (avoid writing common get/set customization by hand): 
  - constant : simply make a getter function returning a constant. Can be passed as the first argument to a Feature constructor.
  - conditional : return different values based on the state of the instrument. The condition must be of the form 'a if driver.b else c' (driver represent the current system not the root driver). When the default kwargs is True (False by default) the result of the condition evaluation is passed as a cmd argument to default_get/set_feature.
- unit utility functions : 
  - to_float : turn something we assume to be a Quantity to a float (should not be used on arbitrary objects) 
  - to_quantity : turn a float in a Quantity if units are supported (no-op otherwise)

Add testing Python 3.5 on Travis.

These are quite simple so in the absence of any comment I will merge in a week or so as they are needed for testing https://github.com/LabPy/lantz_drivers/pull/4
